### PR TITLE
examples/headless-gl: Fix canvas-sketch require statement

### DIFF
--- a/examples/headless-gl.js
+++ b/examples/headless-gl.js
@@ -1,4 +1,4 @@
-const canvasSketch = require('../');
+const canvasSketch = require('canvas-sketch');
 const createShader = require('canvas-sketch-util/shader');
 const glslify = require('glslify');
 


### PR DESCRIPTION
The headless-gl example errors out with:

  Cannot find module '../'

Use 'canvas-sketch' instead.