### PR TITLE
update React example to correctly clean up the canvas-sketch drawing

### DIFF
--- a/examples/canvas-react.js
+++ b/examples/canvas-react.js
@@ -35,12 +35,20 @@ const sketch = ({}) => {
 
 const Sketch = () => {
   const ref = React.createRef();
+
   useEffect(() => {
-    canvasSketch(sketch, {
-      ...settings,
-      canvas: ref.current
-    });
+    const getSketchManager = async () =>
+      await canvasSketch(sketch, {
+        ...settings,
+        canvas: ref.current
+      });
+
+    getSketchManager();
+
+    return () =>
+      getSketchManager().then(sketchManager => sketchManager.destroy());
   }, [ref]);
+
   return <canvas ref={ref} />;
 };
 


### PR DESCRIPTION
we can run some clean up for a component using React's `useEffect` hook simply by ensuring that the function passed to `useEffect` [returns a function](https://reactjs.org/docs/hooks-reference.html#cleaning-up-an-effect).

before our canvas element leaves the DOM, we want to call `.destroy()` on our `SketchManager` instance so that we can remove any event listeners that were set up when the component mounted.