### PR TITLE
Update node-canvas init method in docs

### DIFF
--- a/docs/exporting-artwork.md
+++ b/docs/exporting-artwork.md
@@ -195,10 +195,10 @@ You will need to install the [canvas](https://github.com/Automattic/node-canvas)
 
 ```js
 const canvasSketch = require('canvas-sketch');
-const Canvas = require('canvas');
+const {createCanvas} = require('canvas');
 
 // Create a new 'node-canvas' interface
-const canvas = new Canvas();
+const canvas = createCanvas();
 
 const settings = {
   // Pass in the Cairo-backed canvas


### PR DESCRIPTION
Instantiating using `new Canvas()` throws a `Is not a constructor` error.

It appears in the `node-canvas` [docs](https://github.com/Automattic/node-canvas/blob/master/Readme.md#quick-example) as `createCanvas` being the factory, and confirmed in my own sketches as working 🚀 

Cheers! 