### PR TITLE
Increase zero padding on frame sequence filenames

### DIFF
--- a/lib/save.js
+++ b/lib/save.js
@@ -153,7 +153,7 @@ export function resolveFilename (opt = {}) {
     if (typeof opt.totalFrames === 'number') {
       totalFrames = opt.totalFrames;
     } else {
-      totalFrames = Math.max(1000, opt.frame);
+      totalFrames = Math.max(10000, opt.frame);
     }
     frame = padLeft(String(opt.frame), String(totalFrames).length, '0');
   }


### PR DESCRIPTION
When exporting a long frame sequence (e.g. 18k frames) without defining totalFrames, the filenames are only padded to four digits. I realized this was an issue after I ran ffmpeg and was noticed there were interleaved frames in the video output.