### PR TITLE
fixes threejs examples that use orbit controls

### DIFF
--- a/examples/animated-three-basic-cube.js
+++ b/examples/animated-three-basic-cube.js
@@ -35,7 +35,7 @@ const sketch = ({ context }) => {
   camera.lookAt(new THREE.Vector3());
 
   // Setup camera controller
-  const controls = new THREE.OrbitControls(camera);
+  const controls = new THREE.OrbitControls(camera, context.canvas);
 
   // Setup your scene
   const scene = new THREE.Scene();

--- a/examples/animated-three-text-canvas.js
+++ b/examples/animated-three-text-canvas.js
@@ -77,7 +77,7 @@ const sketch = async ({ context }) => {
   camera.lookAt(new THREE.Vector3());
 
   // set up some orbit controls
-  const controls = new THREE.OrbitControls(camera);
+  const controls = new THREE.OrbitControls(camera, context.canvas);
 
   // setup your scene
   const scene = new THREE.Scene();


### PR DESCRIPTION
Saw this bug that was breaking these examples while I'm poking around and learning things so I figured I'd update it for you as well, `THREE.OrbitControls: The second parameter "domElement" is now mandatory.`

I also noticed the default template that is created when using threejs is the wireframed sphere, but I was going the frontend masters course so that's what led me to come and find the square example. 